### PR TITLE
add "1e-6" to avoid [RuntimWarning: divide by zero encountered in divide or cast]

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ python implementation of the paper: "Efficient Image Dehazing with Boundary Cons
 
 ### method 1
   ```
-  pip install image_dehazer
+  pip install git+https://github.com/XavierJiezou/Single-Image-Dehazing-Python.git
   ```
   
   **Usage:**

--- a/image_dehazer/__init__.py
+++ b/image_dehazer/__init__.py
@@ -32,12 +32,12 @@ class image_dehazer():
     def __BoundCon(self, HazeImg):
         if (len(HazeImg.shape) == 3):
 
-            t_b = np.maximum((self._A[0] - HazeImg[:, :, 0].astype(float)) / (self._A[0] - self.C0),
-                             (HazeImg[:, :, 0].astype(float) - self._A[0]) / (self.C1 - self._A[0]))
-            t_g = np.maximum((self._A[1] - HazeImg[:, :, 1].astype(float)) / (self._A[1] - self.C0),
-                             (HazeImg[:, :, 1].astype(float) - self._A[1]) / (self.C1 - self._A[1]))
-            t_r = np.maximum((self._A[2] - HazeImg[:, :, 2].astype(float)) / (self._A[2] - self.C0),
-                             (HazeImg[:, :, 2].astype(float) - self._A[2]) / (self.C1 - self._A[2]))
+            t_b = np.maximum((self._A[0] - HazeImg[:, :, 0].astype(float)) / (self._A[0] - self.C0 + 1e-6),
+                             (HazeImg[:, :, 0].astype(float) - self._A[0]) / (self.C1 - self._A[0] + 1e-6))
+            t_g = np.maximum((self._A[1] - HazeImg[:, :, 1].astype(float)) / (self._A[1] - self.C0 + 1e-6),
+                             (HazeImg[:, :, 1].astype(float) - self._A[1]) / (self.C1 - self._A[1] + 1e-6))
+            t_r = np.maximum((self._A[2] - HazeImg[:, :, 2].astype(float)) / (self._A[2] - self.C0 + 1e-6),
+                             (HazeImg[:, :, 2].astype(float) - self._A[2]) / (self.C1 - self._A[2] + 1e-6))
 
             MaxVal = np.maximum(t_b, t_g, t_r)
             self._Transmission = np.minimum(MaxVal, 1)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+from setuptools import setup, find_packages
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setup(
+     name='image_dehazer',
+     version='0.0.9',
+     author="utkarsh-deshmukh",
+     author_email="utkarsh.deshmukh@gmail.com",
+     description="remove haze from images",
+     long_description=long_description,
+     long_description_content_type="text/markdown",
+     url="https://github.com/Utkarsh-Deshmukh/Single-Image-Dehazing-Python",
+     download_url="https://github.com/Utkarsh-Deshmukh/Single-Image-Dehazing-Python/archive/master.zip",
+     install_requires=['numpy', 'opencv-python', 'scipy'],
+     license='MIT',
+     keywords=['Single Image Dehazing', 'Haze Removal'],
+     packages=find_packages(),
+     classifiers=[
+         "Programming Language :: Python :: 3",
+         "License :: OSI Approved :: MIT License",
+         "Operating System :: OS Independent",
+     ],
+ )


### PR DESCRIPTION
```python
t_b = np.maximum((self._A[0] - HazeImg[:, :, 0].astype(float)) / (self._A[0] - self.C0 + 1e-6),
                 (HazeImg[:, :, 0].astype(float) - self._A[0]) / (self.C1 - self._A[0] + 1e-6))
t_g = np.maximum((self._A[1] - HazeImg[:, :, 1].astype(float)) / (self._A[1] - self.C0 + 1e-6),
                 (HazeImg[:, :, 1].astype(float) - self._A[1]) / (self.C1 - self._A[1] + 1e-6))
t_r = np.maximum((self._A[2] - HazeImg[:, :, 2].astype(float)) / (self._A[2] - self.C0 + 1e-6),
                 (HazeImg[:, :, 2].astype(float) - self._A[2]) / (self.C1 - self._A[2] + 1e-6))
```