### PR TITLE
Replace deprecated np.alltrue for NumPy 2.0 compatibility

### DIFF
--- a/image_dehazer/__init__.py
+++ b/image_dehazer/__init__.py
@@ -257,7 +257,7 @@ class image_dehazer():
         shape = np.asarray(shape, dtype=int)
         imshape = np.asarray(image.shape, dtype=int)
 
-        if np.alltrue(imshape == shape):
+        if np.all(imshape == shape):
             return image
 
         if np.any(shape <= 0):


### PR DESCRIPTION
The function np.alltrue was deprecated and removed in NumPy 2.0. This commit replaces all instances of np.alltrue with np.all to ensure compatibility with NumPy 2.0 and later versions. The np.all function performs the same check to determine if all elements of an array are True (or meet a given condition).

This change addresses the deprecation warning and ensures that the code works with the latest version of NumPy.